### PR TITLE
[SortingPanel] Modify add-to-collection behavior

### DIFF
--- a/app/src/main/java/org/mozilla/scryer/ScryerService.kt
+++ b/app/src/main/java/org/mozilla/scryer/ScryerService.kt
@@ -19,6 +19,7 @@ import android.support.v4.app.NotificationCompat
 import android.support.v4.content.LocalBroadcastManager
 import android.text.TextUtils
 import android.widget.Toast
+import kotlinx.coroutines.experimental.launch
 import org.mozilla.scryer.capture.RequestCaptureActivity
 import org.mozilla.scryer.capture.ScreenCaptureListener
 import org.mozilla.scryer.capture.ScreenCaptureManager
@@ -167,7 +168,9 @@ class ScryerService : Service(), CaptureButtonController.ClickListener, ScreenCa
                 val model = ScreenshotModel(path,
                         System.currentTimeMillis(),
                         CollectionModel.UNCATEGORIZED)
-                ScryerApplication.getScreenshotRepository().addScreenshot(listOf(model))
+                launch {
+                    ScryerApplication.getScreenshotRepository().addScreenshot(listOf(model))
+                }
             }
         })
     }

--- a/app/src/main/java/org/mozilla/scryer/capture/SortingPanelActivity.kt
+++ b/app/src/main/java/org/mozilla/scryer/capture/SortingPanelActivity.kt
@@ -280,7 +280,9 @@ class SortingPanelActivity : AppCompatActivity() {
     }
 
     private fun onNewCollectionClicked() {
-        CollectionNameDialog.createNewCollection(this, screenshotViewModel)
+        CollectionNameDialog.createNewCollection(this, screenshotViewModel) {
+            onCollectionClicked(it)
+        }
     }
 
     private fun createNewScreenshot(intent: Intent): ScreenshotModel? {

--- a/app/src/main/java/org/mozilla/scryer/landingpage/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/scryer/landingpage/HomeFragment.kt
@@ -41,7 +41,6 @@ import org.mozilla.scryer.capture.SortingPanelActivity
 import org.mozilla.scryer.detailpage.DetailPageActivity
 import org.mozilla.scryer.extension.dpToPx
 import org.mozilla.scryer.filemonitor.ScreenshotFetcher
-import org.mozilla.scryer.overlay.OverlayPermission
 import org.mozilla.scryer.permission.PermissionFlow
 import org.mozilla.scryer.permission.PermissionHelper
 import org.mozilla.scryer.permission.PermissionViewModel
@@ -402,8 +401,14 @@ class HomeFragment : Fragment(), PermissionFlow.ViewDelegate {
         mainListView.addItemDecoration(MainAdapter.ItemDecoration(COLLECTION_COLUMN_COUNT, spaceOuter, spaceTop))
 
         viewModel.getCollections().observe(this, Observer { collections ->
-            collections?.let { newData ->
-                updateCollectionListView(newData)
+            collections?.filter {
+                !CollectionModel.isSuggestCollection(it)
+
+            }?.sortedBy {
+                it.date
+
+            }?.let {
+                updateCollectionListView(it)
             }
         })
 
@@ -529,7 +534,9 @@ class HomeFragment : Fragment(), PermissionFlow.ViewDelegate {
             mainAdapter.notifyDataSetChanged()
         }
 
-        viewModel.addScreenshot(results)
+        launch {
+            viewModel.addScreenshot(results)
+        }
         return results
     }
 

--- a/app/src/main/java/org/mozilla/scryer/landingpage/MainAdapter.kt
+++ b/app/src/main/java/org/mozilla/scryer/landingpage/MainAdapter.kt
@@ -131,7 +131,7 @@ class MainAdapter(private val fragment: Fragment?): RecyclerView.Adapter<Recycle
 
             }?.let { _ ->
                 fragment?.let {
-                    CollectionNameDialog.createNewCollection(parent.context, ScreenshotViewModel.get(it))
+                    CollectionNameDialog.createNewCollection(parent.context, ScreenshotViewModel.get(it)) {}
                 }
             }
         }

--- a/app/src/main/java/org/mozilla/scryer/persistence/CollectionDao.kt
+++ b/app/src/main/java/org/mozilla/scryer/persistence/CollectionDao.kt
@@ -6,24 +6,31 @@
 package org.mozilla.scryer.persistence
 
 import android.arch.lifecycle.LiveData
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Insert
+import android.arch.persistence.room.*
 import android.arch.persistence.room.OnConflictStrategy.REPLACE
-import android.arch.persistence.room.Query
-import android.arch.persistence.room.Update
 
 @Dao
-interface CollectionDao {
+abstract class CollectionDao {
 
     @Query("SELECT * FROM collection")
-    fun getCollections(): LiveData<List<CollectionModel>>
+    abstract fun getCollections(): LiveData<List<CollectionModel>>
 
     @Query("SELECT * FROM collection")
-    fun getCollectionList(): List<CollectionModel>
+    abstract fun getCollectionList(): List<CollectionModel>
 
     @Insert(onConflict = REPLACE)
-    fun addCollection(collection: CollectionModel)
+    abstract fun addCollection(collection: CollectionModel)
 
     @Update(onConflict = REPLACE)
-    fun updateCollection(collection: CollectionModel)
+    abstract fun updateCollection(collection: CollectionModel)
+
+    @Delete
+    abstract fun deleteCollection(collection: CollectionModel)
+
+    @Transaction
+    open fun updateCollectionId(collection: CollectionModel, id: String) {
+        deleteCollection(collection)
+        collection.id = id
+        addCollection(collection)
+    }
 }

--- a/app/src/main/java/org/mozilla/scryer/persistence/CollectionModel.kt
+++ b/app/src/main/java/org/mozilla/scryer/persistence/CollectionModel.kt
@@ -9,11 +9,12 @@ import android.arch.persistence.room.ColumnInfo
 import android.arch.persistence.room.Entity
 import android.arch.persistence.room.Ignore
 import android.arch.persistence.room.PrimaryKey
+import android.graphics.Color
 import java.util.*
 
 @Entity(tableName = "collection")
 data class CollectionModel constructor(
-        @PrimaryKey(autoGenerate = false) val id: String,
+        @PrimaryKey(autoGenerate = false) var id: String,
         @ColumnInfo(name = "name") var name: String,
         @ColumnInfo(name = "date") val date: Long,
         @ColumnInfo(name = "color") val color: Int) {
@@ -28,5 +29,14 @@ data class CollectionModel constructor(
 
         /** Screenshots that had been reviewed by the users without categorizing it */
         const val CATEGORY_NONE = "category_none"
+
+        val suggestCollections = listOf(
+                CollectionModel("default1", "default1", 1, Color.parseColor("#235dff")),
+                CollectionModel("default2", "default2", 2, Color.parseColor("#10c1b6")),
+                CollectionModel("default3", "default3", 3, Color.parseColor("#ffa6a8")))
+
+        fun isSuggestCollection(collection: CollectionModel): Boolean {
+            return suggestCollections.any { it.id == collection.id }
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/scryer/repository/ScreenshotDatabaseRepository.kt
+++ b/app/src/main/java/org/mozilla/scryer/repository/ScreenshotDatabaseRepository.kt
@@ -9,7 +9,6 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Transformations
 import android.content.Context
-import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
 import org.mozilla.scryer.persistence.CollectionModel
@@ -26,9 +25,7 @@ class ScreenshotDatabaseRepository(private val database: ScreenshotDatabase) : S
     private val handler = Handler(Looper.getMainLooper())
 
     override fun addScreenshot(screenshots: List<ScreenshotModel>) {
-        executor.submit {
-            database.screenshotDao().addScreenshot(screenshots)
-        }
+        database.screenshotDao().addScreenshot(screenshots)
     }
 
     override fun updateScreenshot(screenshot: ScreenshotModel) {
@@ -88,13 +85,10 @@ class ScreenshotDatabaseRepository(private val database: ScreenshotDatabase) : S
 
     override fun setupDefaultContent(context: Context) {
         val none = CollectionModel(CollectionModel.CATEGORY_NONE, "Unsorted collection", 0, 0)
-        val shopping = CollectionModel("Shopping", System.currentTimeMillis(), Color.parseColor("#235dff"))
-        val music = CollectionModel("Music", System.currentTimeMillis(), Color.parseColor("#10c1b6"))
-        val secret = CollectionModel("Secret", System.currentTimeMillis(), Color.parseColor("#ffa6a8"))
         addCollection(none)
-        addCollection(shopping)
-        addCollection(music)
-        addCollection(secret)
+        for (collection in CollectionModel.suggestCollections) {
+            addCollection(collection)
+        }
     }
 
     override fun getScreenshotList(callback: (List<ScreenshotModel>) -> Unit) {
@@ -106,12 +100,15 @@ class ScreenshotDatabaseRepository(private val database: ScreenshotDatabase) : S
         }
     }
 
-    override fun getScreenshotList(collectionIds: List<String>, callback: (List<ScreenshotModel>) -> Unit) {
-        executor.execute {
-            val list = database.screenshotDao().getScreenshotList(collectionIds)
-            handler.post {
-                callback(list)
-            }
-        }
+    override fun getScreenshotList(collectionIds: List<String>): List<ScreenshotModel> {
+        return database.screenshotDao().getScreenshotList(collectionIds)
+    }
+
+    override fun deleteCollection(collection: CollectionModel) {
+        database.collectionDao().deleteCollection(collection)
+    }
+
+    override fun updateCollectionId(collection: CollectionModel, id: String) {
+        database.collectionDao().updateCollectionId(collection, id)
     }
 }

--- a/app/src/main/java/org/mozilla/scryer/repository/ScreenshotInMemoryRepository.kt
+++ b/app/src/main/java/org/mozilla/scryer/repository/ScreenshotInMemoryRepository.kt
@@ -69,11 +69,16 @@ class ScreenshotInMemoryRepository : ScreenshotRepository {
         callback(screenshotList)
     }
 
-    override fun getScreenshotList(collectionIds: List<String>, callback: (List<ScreenshotModel>) -> Unit) {
-        callback(screenshotList)
+    override fun getScreenshotList(collectionIds: List<String>): List<ScreenshotModel> {
+        return screenshotList
     }
 
     override fun updateCollection(collection: CollectionModel) {
+    }
 
+    override fun deleteCollection(collection: CollectionModel) {
+    }
+
+    override fun updateCollectionId(collection: CollectionModel, id: String) {
     }
 }

--- a/app/src/main/java/org/mozilla/scryer/repository/ScreenshotRepository.kt
+++ b/app/src/main/java/org/mozilla/scryer/repository/ScreenshotRepository.kt
@@ -35,6 +35,8 @@ interface ScreenshotRepository {
     /** collection_id to model */
     fun getCollectionCovers(): LiveData<Map<String, ScreenshotModel>>
     fun updateCollection(collection: CollectionModel)
+    fun updateCollectionId(collection: CollectionModel, id: String)
+    fun deleteCollection(collection: CollectionModel)
 
     fun addScreenshot(screenshots: List<ScreenshotModel>)
     fun updateScreenshot(screenshot: ScreenshotModel)
@@ -42,7 +44,7 @@ interface ScreenshotRepository {
     fun getScreenshots(): LiveData<List<ScreenshotModel>>
     fun getScreenshotList(callback: (List<ScreenshotModel>) -> Unit)
     fun getScreenshots(collectionIds: List<String>): LiveData<List<ScreenshotModel>>
-    fun getScreenshotList(collectionIds: List<String>, callback: (List<ScreenshotModel>) -> Unit)
+    fun getScreenshotList(collectionIds: List<String>): List<ScreenshotModel>
     fun deleteScreenshot(screenshot: ScreenshotModel)
 
     fun setupDefaultContent(context: Context) {

--- a/app/src/main/java/org/mozilla/scryer/sortingpanel/SortingPanel.kt
+++ b/app/src/main/java/org/mozilla/scryer/sortingpanel/SortingPanel.kt
@@ -53,6 +53,9 @@ class SortingPanel : FrameLayout, DefaultLifecycleObserver {
         it?.filter {
             it.id != CollectionModel.CATEGORY_NONE
 
+        }?.sortedBy {
+            it.date
+
         }?.let {
             this.adapter.collections = it
             this.adapter.notifyDataSetChanged()

--- a/app/src/main/java/org/mozilla/scryer/ui/CollectionNameDialog.kt
+++ b/app/src/main/java/org/mozilla/scryer/ui/CollectionNameDialog.kt
@@ -24,9 +24,10 @@ class CollectionNameDialog(private val context: Context,
                            private val delegate: Delegate) {
 
     companion object {
-        fun createNewCollection(context: Context, viewModel: ScreenshotViewModel) {
+        fun createNewCollection(context: Context, viewModel: ScreenshotViewModel,
+                                callback: (collection: CollectionModel) -> Unit) {
             launch(UI) {
-                createNewCollection(context, viewModel, getCollectionList(viewModel))
+                createNewCollection(context, viewModel, getCollectionList(viewModel), callback)
             }
         }
 
@@ -40,12 +41,14 @@ class CollectionNameDialog(private val context: Context,
         }
 
         private fun createNewCollection(context: Context, viewModel: ScreenshotViewModel,
-                                        collections: List<CollectionModel>) {
+                                        collections: List<CollectionModel>,
+                                        callback: (collection: CollectionModel) -> Unit) {
             val dialog = CollectionNameDialog(context, collections, object : CollectionNameDialog.Delegate {
                 override fun onPositiveAction(dialog: CollectionNameDialog.Interface) {
                     val color = findColorForNewCollection(context, collections)
                     val model = CollectionModel(dialog.getInputText(), System.currentTimeMillis(), color)
                     viewModel.addCollection(model)
+                    callback(model)
                 }
 
                 override fun onNegativeAction(dialog: CollectionNameDialog.Interface) {}


### PR DESCRIPTION
1. After the user creates a new collection, directly add the screenshot to that collection.
2. There will be several predefined suggest collections, which is only visible on the sorting panel, and will become visible on the home page after the user had added screenshots to that collection.